### PR TITLE
Introduce PR Linter

### DIFF
--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -1,0 +1,82 @@
+---
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  id-token: write  # required to use OIDC authentication
+  contents: write  # required to checkout the code from the repo and to perform release
+  packages: write  # required to publish to packages
+  pull-requests: write
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure which types are allowed (newline delimited).
+          # Default: https://github.com/commitizen/conventional-commit-types
+          types: |
+            docs
+            feat
+            fix
+            improvement
+            refactor
+            revert
+            test
+          # Configure which scopes are allowed (newline delimited).
+          scopes: |
+            infra
+            core
+            ci/cd
+            ui
+            deps
+          # Configure that a scope must always be provided.
+          requireScope: false
+          # Configure which scopes (newline delimited) are disallowed in PR
+          # titles. For instance by setting # the value below, `chore(release):
+          # ...` and `ci(e2e,release): ...` will be rejected.
+          disallowScopes: |
+            release
+          # Configure additional validation for the subject based on a regex.
+          # This example ensures the subject doesn't start with an uppercase character.
+          subjectPattern: ^(?![A-Z]).+$
+          # If `subjectPattern` is configured, you can use this property to override
+          # the default error message that is shown when the pattern doesn't match.
+          # The variables `subject` and `title` can be used within the message.
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+          # If you use GitHub Enterprise, you can set this to the URL of your server
+          # githubBaseUrl: https://github.myorg.com/api/v3
+          # If the PR contains one of these labels (newline delimited), the
+          # validation is skipped.
+          # If you want to rerun the validation when labels change, you might want
+          # to use the `labeled` and `unlabeled` event triggers in your workflow.
+          ignoreLabels: |
+            bot
+            ignore-semantic-pull-request
+          # If you're using a format for the PR title that differs from the traditional Conventional
+          # Commits spec, you can use these options to customize the parsing of the type, scope and
+          # subject. The `headerPattern` should contain a regex where the capturing groups in parentheses
+          # correspond to the parts listed in `headerPatternCorrespondence`.
+          # See: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#headerpattern
+          headerPattern: '^(\w*)(?:\(([\w$.\-*/ ]*)\))?: (.*)$'
+          headerPatternCorrespondence: type, scope, subject
+          # For work-in-progress PRs you can typically use draft pull requests
+          # from GitHub. However, private repositories on the free plan don't have
+          # this option and therefore this action allows you to opt-in to using the
+          # special "[WIP]" prefix to indicate this state. This will avoid the
+          # validation of the PR title and the pull request checks remain pending.
+          # Note that a second check will be reported if this is enabled.
+          wip: false


### PR DESCRIPTION
Introduce PR Linter which should validate PR Title - just one of good practices
## Checklist before requesting a review

- [ ] A self-review of the code has been performed
- [ ] Commit messages and code follows our `guidelines and standards`
- [ ] Tests have been added or updated where appropriate
- [ ] Changes generate no new errors or warnings
- [ ] There are no open [Pull Requests](../../../pulls) for the same update/change
- [ ] Any dependent changes have been merged and published
- [ ] This change is covered by a project issue ticket

<!--- SECTIONS THAT DO NOT APPLY CAN BE REMOVED-->

## Change Description
Add new workflow file to be triggered every time once PR is being created, edited or synchronized.

